### PR TITLE
README: Add some shields.io labels

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,6 +2,10 @@
 
 ![Logo](img/md_logo.png)
 
+[![Release](https://img.shields.io/github/tag/letsgamedev/spielsklave.svg)](https://github.com/letsgamedev/spielsklave/releases)
+[![Issues](https://img.shields.io/github/issues/letsgamedev/spielsklave.svg)](https://github.com/letsgamedev/spielsklave/issues)
+[![Contributors](https://img.shields.io/github/contributors/letsgamedev/spielsklave.svg)](https://github.com/letsgamedev/spielsklave/graphs/contributors)
+
 **Klicke [HIER](README.md) für die Deutsche Version.**
 
 Spielsklave (*lit. "game slave"*) is a German [video series on YouTube](https://www.youtube.com/playlist?list=PL1td_Fr5vMGNqmdJOfnxDPKo_nO87Rs47).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ![Logo](img/md_logo.png)
 
+[![Release](https://img.shields.io/github/tag/letsgamedev/spielsklave.svg)](https://github.com/letsgamedev/spielsklave/releases)
+[![Issues](https://img.shields.io/github/issues/letsgamedev/spielsklave.svg)](https://github.com/letsgamedev/spielsklave/issues)
+[![Contributors](https://img.shields.io/github/contributors/letsgamedev/spielsklave.svg)](https://github.com/letsgamedev/spielsklave/graphs/contributors)
+
 **Click [HERE](README.en.md) for the English version.**
 
 Bei Spielsklave handelt es sich um eine [Videoreihe](https://www.youtube.com/playlist?list=PL1td_Fr5vMGNqmdJOfnxDPKo_nO87Rs47), in der **du** darüber abstimmen kannst, was ich als Nächstes entwickeln soll!


### PR DESCRIPTION
Rendered README with changes:
https://github.com/LNJ2/spielsklave/blob/readme-labels/README.md

This adds three labels/buttons with information about the current release of spielsklave, the number of open issues/pull requests and the number of contributors. There are many others available, see: http://shields.io/. E.g. a label for the license or the web server status might also be helpful.


Current labels in this PR:
[![Release](https://img.shields.io/github/tag/letsgamedev/spielsklave.svg)](https://github.com/letsgamedev/spielsklave/releases)
[![Issues](https://img.shields.io/github/issues/letsgamedev/spielsklave.svg)](https://github.com/letsgamedev/spielsklave/issues)
[![Contributors](https://img.shields.io/github/contributors/letsgamedev/spielsklave.svg)](https://github.com/letsgamedev/spielsklave/graphs/contributors)


--
A tip for merging: You can use 'Squash & Merge' in the drop down menu on github to merge a whole pull request into a single commit, there you can also change the description and if you do it this way there also won't be all these empty merge commits (Merge pull request .... from ...).